### PR TITLE
fix: #ENABLING-956, add truncate as a write operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>fr.wseduc</groupId>
   <artifactId>mod-postgresql</artifactId>
-  <version>2.2-SNAPSHOT</version>
+  <version>2.2-develop-enabling-SNAPSHOT</version>
 
   <properties>
     <web-utils.version>3.4-SNAPSHOT</web-utils.version>

--- a/src/main/java/fr/wseduc/sql/SqlPersistor.java
+++ b/src/main/java/fr/wseduc/sql/SqlPersistor.java
@@ -40,7 +40,7 @@ public class SqlPersistor extends BusModBase implements Handler<Message<JsonObje
 	private HikariDataSource ds;
 	private HikariDataSource dsSlave;
 	private Pattern writingClausesPattern = Pattern.compile(
-			"(update\\s+|create\\s+|merge_|delete\\s+|remove\\s+|insert\\s+|alter\\s+|add\\s+|drop\\s+|constraint\\s+|\\s+nextval" +
+			"(update\\s+|create\\s+|merge_|delete\\s+|remove\\s+|insert\\s+|alter\\s+|add\\s+|drop\\s+|truncate\\s+|constraint\\s+|\\s+nextval" +
 			"|insert_users_members|insert_group_members|function_|reset_time_slots|delete_trombinoscope_failure|delete_incident)",
 			Pattern.CASE_INSENSITIVE);
 


### PR DESCRIPTION
Cette PR ajoute l'opération TRUNCATE en tant qu'opé d'écriture de façon à ce qu'elle soit redirigée vers le noeud primaire, sinon on a des erreurs comme celle-ci :

```json
{"mttr":"","exception":"org.postgresql.util.PSQLException: ERROR: cannot execute TRUNCATE TABLE in a read-only transaction\n\tat org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2565)\n\tat org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2297)\n\tat org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:322)\n\tat org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:481)\n\tat org.postgresql.jdbc.PgStatement.execute(PgStatement.java:401)\n\tat org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:322)\n\tat org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:308)\n\tat org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:284)\n\tat org.postgresql.jdbc.PgStatement.execute(PgStatement.java:279)\n\tat com.zaxxer.hikari.pool.ProxyStatement.execute(ProxyStatement.java:95)\n\tat com.zaxxer.hikari.pool.HikariProxyStatement.execute(HikariProxyStatement.java)\n\tat fr.wseduc.sql.SqlPersistor.raw(SqlPersistor.java:178)\n\tat fr.wseduc.sql.SqlPersistor.raw(SqlPersistor.java:166)\n\tat fr.wseduc.sql.SqlPersistor.doRaw(SqlPersistor.java:141)\n\tat fr.wseduc.sql.SqlPersistor.lambda$handle$0(SqlPersistor.java:115)\n\tat io.vertx.core.impl.ContextImpl.lambda$executeBlocking$0(ContextImpl.java:178)\n\tat io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:279)\n\tat io.vertx.core.impl.ContextImpl.lambda$internalExecuteBlocking$2(ContextImpl.java:210)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.lang.Thread.run(Thread.java:750)","workload_type":"other","timestamp":"2026-06-19T11:00:15.155Z","level":"ERROR","workload_name":"vertx-statistics-presences","logger":"org.vertx.java.busmods.BusModBase","traceId":"","message":"ERROR: cannot execute TRUNCATE TABLE in a read-only transaction","engine":"vertx"}
```